### PR TITLE
Update dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": ["env"],
+  "only": ["src{/**,}/*.es", "test{/**,}/*.es"],
+  "sourceMaps": "inline"
+}

--- a/test/ts/usage.ts
+++ b/test/ts/usage.ts
@@ -1,7 +1,7 @@
 // This file is meant to be compiled but not executed.  It tests our type declarations.
 
-import alsoOutdent from '../../';
-import {outdent, Outdent, Options} from '../../';
+import alsoOutdent from "../../";
+import {outdent, Outdent, Options} from "../../";
 
 let s: string;
 s = outdent `


### PR DESCRIPTION
- Update Babel dependencies
  - Switch from `babel-preset-es2015` to `babel-preset-env`
- Update Mocha
  - Use `--require` instead of deprecated `--compiler` Mocha option
- Update Chai
- Update TypeScript
- Use `"` in TypeScript test instead of `'`