### PR TITLE
Add support for outdenting string arguments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: node_js
 node_js:
-  - "stable"
-  - "4.2.3"
+  # Test on latest stable and lts versions
+  - "lts/*"
+  - "node"
 
 # For performance:
 sudo: false
 git:
   depth: 1
+
+install:
+  # Run `npm ci` if appropriate and version of npm is new enough; otherwise `npm install`
+  - if [ -f package-lock.json ] && [ npm ci --help 2>&1 >/dev/null ] ; then npm ci ; else npm install ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ git:
 
 install:
   # Run `npm ci` if appropriate and version of npm is new enough; otherwise `npm install`
-  - if [ -f package-lock.json ] && [ npm ci --help 2>&1 >/dev/null ] ; then npm ci ; else npm install ; fi
+  - if [ -f package-lock.json ] && npm ci --help 2>&1 >/dev/null ; then npm ci ; else npm install ; fi
 
 # Cache node_modules (unless there is no benefit)
 cache:
@@ -19,4 +19,4 @@ cache:
     - node_modules
 before_cache:
   # Suppress caching node_modules if it won't do any good.  `npm ci` ignores and throws away pre-existing `node_module`
-  - if [ -f package-lock.json ] && [ npm ci --help 2>&1 >/dev/null ] ; then mv node_modules node_modules_do_not_cache ; fi
+  - if [ -f package-lock.json ] && npm ci --help 2>&1 >/dev/null ; then mv node_modules node_modules_do_not_cache ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,11 @@ git:
 install:
   # Run `npm ci` if appropriate and version of npm is new enough; otherwise `npm install`
   - if [ -f package-lock.json ] && [ npm ci --help 2>&1 >/dev/null ] ; then npm ci ; else npm install ; fi
+
+# Cache node_modules (unless there is no benefit)
+cache:
+  directories:
+    - node_modules
+before_cache:
+  # Suppress caching node_modules if it won't do any good.  `npm ci` ignores and throws away pre-existing `node_module`
+  - if [ -f package-lock.json ] && [ npm ci --help 2>&1 >/dev/null ] ; then mv node_modules node_modules_do_not_cache ; fi

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ assert(output === '  Yo\n345\n    Hello world');
 *Note: `${outdent}` must be alone on its own line without anything before or after it. It cannot be preceded by any non-whitespace characters.*
 *If these conditions are not met, outdent will follow normal indentation-detection behavior.*
 
+Outdent can also remove indentation from plain strings via the `string` method.
+
+```javascript
+const output = outdent.string('\n    Hello world!\n');
+
+assert(output === 'Hello world!');
+```
+
 ### Options
 
 #### `trimLeadingNewline`

--- a/package-lock.json
+++ b/package-lock.json
@@ -763,9 +763,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
       "dev": true
     },
     "typescript-formatter": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ts-node": "^3.3.0",
     "tslint": "^5.9.1",
     "tslint-language-service": "^0.9.6",
-    "typescript": "^2.5.3",
+    "typescript": "^2.7.2",
     "typescript-formatter": "^6.0.0",
     "which": "^1.3.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,14 +111,11 @@ function createInstance(options: Options): Outdent {
     const cache = createWeakMap<TemplateStringsArray, string>();
 
     /* tslint:disable:no-shadowed-variable */
-    function outdent(stringsOrOptions: string): string;
     function outdent(stringsOrOptions: TemplateStringsArray, ...values: Array<any>): string;
     function outdent(stringsOrOptions: Options): Outdent;
-    function outdent(stringsOrOptions: string | TemplateStringsArray | Options, ...values: Array<any>): string | Outdent {
+    function outdent(stringsOrOptions: TemplateStringsArray | Options, ...values: Array<any>): string | Outdent {
         /* tslint:enable:no-shadowed-variable */
-        if(typeof stringsOrOptions === 'string') {
-            return _outdent([stringsOrOptions], [], outdent, options);
-        } else if(isTemplateStringsArray(stringsOrOptions)) {
+        if(isTemplateStringsArray(stringsOrOptions)) {
             // TODO Enable semi-caching, both when the first interpolated value is `outdent`, and when it's not
             const strings = stringsOrOptions;
             // Serve from cache only if there are no interpolated values
@@ -136,6 +133,10 @@ function createInstance(options: Options): Outdent {
         }
     }
 
+    (outdent as any).string = (str: string): string => {
+      return _outdent([str], [], outdent, options);
+    };
+
     return outdent;
 }
 
@@ -145,10 +146,6 @@ const outdent = createInstance({
 });
 
 export interface Outdent {
-    /**
-     * Remove indentation from a string.
-     */
-    (str: string): string;
     /**
      * Remove indentation from a template literal.
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,11 +111,14 @@ function createInstance(options: Options): Outdent {
     const cache = createWeakMap<TemplateStringsArray, string>();
 
     /* tslint:disable:no-shadowed-variable */
+    function outdent(stringsOrOptions: string): string;
     function outdent(stringsOrOptions: TemplateStringsArray, ...values: Array<any>): string;
     function outdent(stringsOrOptions: Options): Outdent;
-    function outdent(stringsOrOptions: TemplateStringsArray | Options, ...values: Array<any>): string | Outdent {
+    function outdent(stringsOrOptions: string | TemplateStringsArray | Options, ...values: Array<any>): string | Outdent {
         /* tslint:enable:no-shadowed-variable */
-        if(isTemplateStringsArray(stringsOrOptions)) {
+        if(typeof stringsOrOptions === 'string') {
+            return _outdent([stringsOrOptions], [], outdent, options);
+        } else if(isTemplateStringsArray(stringsOrOptions)) {
             // TODO Enable semi-caching, both when the first interpolated value is `outdent`, and when it's not
             const strings = stringsOrOptions;
             // Serve from cache only if there are no interpolated values
@@ -142,6 +145,10 @@ const outdent = createInstance({
 });
 
 export interface Outdent {
+    /**
+     * Remove indentation from a string.
+     */
+    (str: string): string;
     /**
      * Remove indentation from a template literal.
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,13 +30,14 @@ const has = function(obj: object, prop: string): boolean {
 };
 
 // Copy all own enumerable properties from source to target
-function extend(target: TODO, source: TODO): TODO {
+function extend<T, S extends object>(target: T, source: S) {
+    type Extended = T & { [K in keyof S]: S[K] };
     for(const prop in source) {
         if(has(source, prop)) {
-            target[prop] = source[prop];
+            (target as Extended)[prop] = source[prop];
         }
     }
-    return target;
+    return target as Extended;
 }
 
 const reLeadingNewline = /^[ \t]*(?:\r\n|\r|\n)/;

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ function createInstance(options: Options): Outdent {
             if(values.length === 0 && cache.has(strings)) return cache.get(strings)!;
 
             // Perform outdentation
-            const rendered = _outdent(strings, values, outdent, options);
+            const rendered = _outdent(strings, values, fullOutdent, options);
 
             // Store into the cache only if there are no interpolated values
             values.length === 0 && cache.set(strings, rendered);
@@ -134,11 +134,13 @@ function createInstance(options: Options): Outdent {
         }
     }
 
-    (outdent as any).string = (str: string): string => {
-      return _outdent([str], [], outdent, options);
-    };
+    const fullOutdent = extend(outdent, {
+        string(str: string): string {
+            return _outdent([str], [], fullOutdent, options);
+        },
+    });
 
-    return outdent;
+    return fullOutdent;
 }
 
 const outdent = createInstance({
@@ -155,6 +157,11 @@ export interface Outdent {
      * Create and return a new Outdent instance with the given options.
      */
     (options: Options): Outdent;
+
+    /**
+     * Remove indentation from a string
+     */
+    string(str: string): string;
 }
 export interface Options {
     trimLeadingNewline?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,10 @@ const has = function(obj: object, prop: string): boolean {
 
 // Copy all own enumerable properties from source to target
 function extend<T, S extends object>(target: T, source: S) {
-    type Extended = T & {[K in keyof S]: S[K]};
+    type Extended = T & S;
     for(const prop in source) {
         if(has(source, prop)) {
-            (target as Extended)[prop] = source[prop];
+            (target as any)[prop] = source[prop];
         }
     }
     return target as Extended;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ const has = function(obj: object, prop: string): boolean {
 
 // Copy all own enumerable properties from source to target
 function extend<T, S extends object>(target: T, source: S) {
-    type Extended = T & { [K in keyof S]: S[K] };
+    type Extended = T & {[K in keyof S]: S[K]};
     for(const prop in source) {
         if(has(source, prop)) {
             (target as Extended)[prop] = source[prop];

--- a/test/spec/spec.ts
+++ b/test/spec/spec.ts
@@ -7,7 +7,6 @@ function makeStrings(...strings: Array<string>): TemplateStringsArray {
 }
 
 describe('outdent', () => {
-
     it('Removes indentation', () => {
         expect(outdent`
             Hello
@@ -35,7 +34,7 @@ describe('outdent', () => {
         expect(outdent`
             Hello
             World
-            
+
         `).to.equal('Hello\nWorld\n');
     });
 
@@ -62,7 +61,7 @@ removed
         `).to.equal('Hello\n\nWorld');
         expect(outdent`
             Hello
-     
+
             World
         `).to.equal('Hello\n\nWorld');
     });
@@ -94,7 +93,7 @@ removed
             `).to.equal('5678');
 
             expect(od`
-            
+
                 ${ od }
             12345678
             `).to.equal('5678');
@@ -153,7 +152,6 @@ removed
             Hello
             World
         `).to.equal('Hello\nWorld\n');
-
     });
     it('Does not trim trailing nor leading newline when asked not to', () => {
         expect(outdent({
@@ -174,14 +172,14 @@ removed
             trimLeadingNewline: false,
             trimTrailingNewline: false,
         }) `
-        
+
         `).to.equal('\n\n');
     });
 
     it('Merges options objects', () => {
         const customOutdent = outdent({ trimLeadingNewline: false })({ trimTrailingNewline: false });
         expect(customOutdent`
-        
+
         `).to.equal('\n\n');
 
         expect(customOutdent({ trimLeadingNewline: true }) `
@@ -214,5 +212,14 @@ removed
     it('Accepts strings with no content after the first newline', () => {
         expect(outdent`Hello world!
         `).to.equal('Hello world!');
+    });
+
+    it('Can be called like a function, passing a string to it.', () => {
+        expect(
+            outdent(`
+                Hello world!
+                  Hello world!
+            `)
+        ).to.equal('Hello world!\n  Hello world!');
     });
 });

--- a/test/spec/spec.ts
+++ b/test/spec/spec.ts
@@ -69,7 +69,7 @@ removed
     it('Preserves trailing spaces on blank lines', () => {
         expect(outdent`
             Hello
-              
+
             World
         `).to.equal('Hello\n  \nWorld');
     });
@@ -214,9 +214,9 @@ removed
         `).to.equal('Hello world!');
     });
 
-    it('Can be called like a function, passing a string to it.', () => {
+    it('outdent.string takes strings as input and formats them', () => {
         expect(
-            outdent(`
+            outdent.string(`
                 Hello world!
                   Hello world!
             `)

--- a/test/spec/spec.ts
+++ b/test/spec/spec.ts
@@ -7,6 +7,7 @@ function makeStrings(...strings: Array<string>): TemplateStringsArray {
 }
 
 describe('outdent', () => {
+
     it('Removes indentation', () => {
         expect(outdent`
             Hello
@@ -34,7 +35,7 @@ describe('outdent', () => {
         expect(outdent`
             Hello
             World
-
+            
         `).to.equal('Hello\nWorld\n');
     });
 
@@ -61,7 +62,7 @@ removed
         `).to.equal('Hello\n\nWorld');
         expect(outdent`
             Hello
-
+     
             World
         `).to.equal('Hello\n\nWorld');
     });
@@ -69,7 +70,7 @@ removed
     it('Preserves trailing spaces on blank lines', () => {
         expect(outdent`
             Hello
-
+              
             World
         `).to.equal('Hello\n  \nWorld');
     });
@@ -93,7 +94,7 @@ removed
             `).to.equal('5678');
 
             expect(od`
-
+            
                 ${ od }
             12345678
             `).to.equal('5678');
@@ -152,6 +153,7 @@ removed
             Hello
             World
         `).to.equal('Hello\nWorld\n');
+
     });
     it('Does not trim trailing nor leading newline when asked not to', () => {
         expect(outdent({
@@ -172,14 +174,14 @@ removed
             trimLeadingNewline: false,
             trimTrailingNewline: false,
         }) `
-
+        
         `).to.equal('\n\n');
     });
 
     it('Merges options objects', () => {
         const customOutdent = outdent({ trimLeadingNewline: false })({ trimTrailingNewline: false });
         expect(customOutdent`
-
+        
         `).to.equal('\n\n');
 
         expect(customOutdent({ trimLeadingNewline: true }) `

--- a/test/ts/usage.ts
+++ b/test/ts/usage.ts
@@ -13,3 +13,8 @@ const newOutdent2 = newOutdent1({ trimLeadingNewline: false });
 s = newOutdent2`
     hello ${ 123 } world`;
 const outdent2: Outdent = newOutdent2;
+s = outdent(`
+    bar
+      baz
+        qux
+`);

--- a/test/ts/usage.ts
+++ b/test/ts/usage.ts
@@ -13,7 +13,7 @@ const newOutdent2 = newOutdent1({ trimLeadingNewline: false });
 s = newOutdent2`
     hello ${ 123 } world`;
 const outdent2: Outdent = newOutdent2;
-s = outdent(`
+s = outdent.string(`
     bar
       baz
         qux


### PR DESCRIPTION
I'm not sure what your stance is on this but I thought I'd raise a PR just in case, as opposed to just raising an issue.

## Use case

My use case for this is that we're using `outdent` to outdent code blocks for our `Code` component that highlights the input `text`:

```js
<Code
  text={`
    Needs
      outdenting
  `}
/>
```

We could use it as part of that template literal, but what we want is for outdenting to automatically happen on the template strings in the component. In order to do this, we need to be able to format strings. Our current solution is to trick `outdent` by providing it an array with the `raw` property like so:

```js
// @flow

type LitArray = Array<any> & {
  raw: Array<string>,
};

// This converts a string to the shape of a parsed literal that the outdent
// lit function uses.
export function strToLit(str: string): LitArray {
  const strAsLitArr: any = [str];
  Object.defineProperty(strAsLitArr, 'raw', {
    configurable: true,
    value: [str],
  });
  return strAsLitArr;
}
```

However, it feels like providing this behaviour as part of `outdent` itself is a far better idea.

## Testing

I've tested locally using `npm test` and everything passes. However, we're getting the following error in CI:

```
ERROR: test/spec/spec.ts[1, 24]: Module 'chai' is not listed as dependency in package.json
```

Are you aware of this? If not, I can investigate and fix.